### PR TITLE
Add FuseSoC support and Github CI actions

### DIFF
--- a/.github/workflows/fusesoc.yml
+++ b/.github/workflows/fusesoc.yml
@@ -1,0 +1,33 @@
+name: run-fusesoc-targets
+on: [push]
+
+jobs:
+  build-openlane-sky130:
+    runs-on: ubuntu-latest
+    env:
+      REPO : Booth_Multipliers
+      VLNV : booth_multipliers
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: Booth_Multipliers
+      - run: echo "EDALIZE_LAUNCHER=el_docker" >> $GITHUB_ENV
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=sky130_4xA $VLNV
+
+  lint-verilator:
+    runs-on: ubuntu-latest
+    env:
+      REPO : Booth_Multipliers
+      VLNV : booth_multipliers
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: Booth_Multipliers
+      - run: sudo apt install verilator
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=lint_4xA $VLNV

--- a/booth_multipliers.core
+++ b/booth_multipliers.core
@@ -1,0 +1,34 @@
+CAPI=2:
+
+name : ::booth_multipliers:0
+
+filesets:
+  rtl:
+    files:
+      - Src/Booth_Multiplier_1xA.v
+      - Src/Booth_Multiplier_2x.v
+      - Src/Booth_Multiplier_4xA.v
+      - Src/Booth_Multiplier_4xB.v
+      - Src/Booth_Multiplier_4x.v
+      - Src/Booth_Multiplier.v
+    file_type : verilogSource
+
+  sky130:
+    files: [data/sky130.tcl : {file_type : tclSource}]
+    
+targets:
+  default:
+    filesets : [rtl]
+
+  lint_4xA:
+    default_tool: verilator
+    filesets : [rtl]
+    tools:
+      verilator:
+        mode: lint-only
+    toplevel : Booth_Multiplier_4xA
+
+  sky130_4xA:
+    default_tool : openlane
+    filesets : [rtl, sky130]
+    toplevel : Booth_Multiplier_4xA

--- a/data/sky130.tcl
+++ b/data/sky130.tcl
@@ -1,0 +1,6 @@
+set ::env(CLOCK_PORT) "Clk"
+set ::env(CLOCK_NET) $::env(CLOCK_PORT)
+set ::env(SYNTH_MAX_FANOUT) 6
+set ::env(CLOCK_PERIOD) "20.0"
+set ::env(FP_CORE_UTIL) 18
+set ::env(PL_TARGET_DENSITY) [ expr ($::env(FP_CORE_UTIL)+5) / 100.0 ]


### PR DESCRIPTION
This adds a core description file for the booth_multipliers core that exposes targets for linting and for building a GDSII using OpenLANE. All targets are also implemented as Github actions so that they get run on every push to the repo.

Quick FuseSoC instructions:

 #install FuseSoC
pip3 install fusesoc
 #Create and enter a new workspace
mkdir workspace && cd workspace
 #Register booth_multipliers as a library in the workspace
fusesoc library add booth_multipliers /path/to/booth_multipliers
 #...if repo is available locally or...
fusesoc library add booth_multipliers https://github.com/MorrisMA/Booth_Multipliers
 #...to get the upstream repo

 #To run lint
fusesoc run --target=lint_4xA booth_multipliers
 #To build with OpenLANE running in a docker container
EDALIZE_LAUNCHER=el_docker fusesoc run --target=sky130_4xA booth_multipliers
 #List all targets
fusesoc core show booth_multipliers